### PR TITLE
chore: remove test files form package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # Current director
 PROJECT_DIR=$(shell pwd)
 
-BUILD_NUMBER=2
+BUILD_NUMBER=3
 
 # Version of packages that will be compiled by this meta-package
 PYTHON_VERSION=3.5.2
@@ -276,6 +276,8 @@ endif
 $$(PYTHON_DIR-$1)/dist/lib/libpython$(PYTHON_VER).a: build/$2/OpenSSL.framework build/$2/BZip2.framework build/$2/XZ.framework $$(PYTHON_DIR-$1)/Makefile
 	# Build target Python
 	cd $$(PYTHON_DIR-$1) && PATH=$(PROJECT_DIR)/$(PYTHON_DIR-macOS)/dist/bin:$(PATH) make all install
+	# removing unecessary test files from build
+	rm -rf $(PYTHON_DIR-macOS)/dist/lib/python$(PYTHON_VER)/test
 
 build/$2/$$(pyconfig.h-$1): $$(PYTHON_DIR-$1)/dist/include/python$(PYTHON_VER)/pyconfig.h
 	cp -f $$^ $$@


### PR DESCRIPTION
This merge removes all test files from macOS package. It got roughly 33% smaller (around 10mb) 
