### PR TITLE
Fix for missing hash functions from hashlib

### DIFF
--- a/patch/Python/Setup.embedded
+++ b/patch/Python/Setup.embedded
@@ -42,6 +42,7 @@ _sqlite3 -I$(srcdir)/Modules/_sqlite -DMODULE_NAME='\"sqlite3\"' -DSQLITE_OMIT_L
     _sqlite/statement.c \
     _sqlite/util.c
 _ssl _ssl.c -I$(srcdir)/../openssl/include -L$(srcdir)/../Support/OpenSSL -lOpenSSL -DUSE_SSL
+_hashlib _hashopenssl.c -I$(srcdir)/../openssl/include -L$(srcdir)/../Support/OpenSSL -lOpenSSL -DUSE_SSL
 _struct _struct.c
 array arraymodule.c
 audioop audioop.c


### PR DESCRIPTION
Hashlib has a c file it uses to query openssl for the hash functions it provides.  Since this file was missing from the embedded module spec, hashlib only had a few basic hash functions.

This enables things like rimpemd160, etc that come from openssl.

Thanks in advance!